### PR TITLE
Changes to named arguments. (Fix for tf 1.0.0)

### DIFF
--- a/gcn/metrics.py
+++ b/gcn/metrics.py
@@ -3,7 +3,7 @@ import tensorflow as tf
 
 def masked_softmax_cross_entropy(preds, labels, mask):
     """Softmax cross-entropy loss with masking."""
-    loss = tf.nn.softmax_cross_entropy_with_logits(preds, labels)
+    loss = tf.nn.softmax_cross_entropy_with_logits(logits=preds, lables=labels)
     mask = tf.cast(mask, dtype=tf.float32)
     mask /= tf.reduce_mean(mask)
     loss *= mask

--- a/gcn/metrics.py
+++ b/gcn/metrics.py
@@ -3,7 +3,7 @@ import tensorflow as tf
 
 def masked_softmax_cross_entropy(preds, labels, mask):
     """Softmax cross-entropy loss with masking."""
-    loss = tf.nn.softmax_cross_entropy_with_logits(logits=preds, lables=labels)
+    loss = tf.nn.softmax_cross_entropy_with_logits(logits=preds, labels=labels)
     mask = tf.cast(mask, dtype=tf.float32)
     mask /= tf.reduce_mean(mask)
     loss *= mask


### PR DESCRIPTION
To avoid confusion, tf.nn.softmax_cross_entropy_with_logits only accepts named arguments in Tensorflow 1.0.0.