### PR TITLE
Fix wrong pickle load

### DIFF
--- a/gcn/utils.py
+++ b/gcn/utils.py
@@ -6,13 +6,21 @@ from scipy.sparse.linalg.eigen.arpack import eigsh
 import sys
 
 
+PKL_ENCODING = "latin-1" # ASCII, latin-1
+
+
 def parse_index_file(filename):
     """Parse index file."""
     index = []
-    for line in open(filename):
-        index.append(int(line.strip()))
-    return index
-
+    # checks if the file was created using pickle module
+    try:
+        with open(filename, 'rb') as f:
+            return pkl.load(f, encoding=PKL_ENCODING)
+    except:
+        for line in open(filename):
+            index.append(int(line.strip()))
+        return index
+        
 
 def sample_mask(idx, l):
     """Create mask."""
@@ -46,20 +54,13 @@ def load_data(dataset_str):
     for i in range(len(names)):
         with open("data/ind.{}.{}".format(dataset_str, names[i]), 'rb') as f:
             if sys.version_info > (3, 0):            
-                objects.append(pkl.load(f, encoding="ASCII"))              
+                objects.append(pkl.load(f, encoding=PKL_ENCODING))              
             else:
-                objects.append(pkl.load(f, encoding="latin-1" ))
+                objects.append(pkl.load(f))
 
     x, y, tx, ty, allx, ally, graph = tuple(objects)
-    
-    if sys.version_info > (3, 0):
-        test_idx_reorder = None
-        with open("data/ind.{}.test.index".format(dataset_str), 'rb') as f:
-                if sys.version_info > (3, 0):               
-                    test_idx_reorder = pkl.load(f, encoding="ASCII")
-    else:
-        test_idx_reorder = parse_index_file("data/ind.{}.test.index".format(dataset_str))          
-    
+      
+    test_idx_reorder = parse_index_file("data/ind.{}.test.index".format(dataset_str))          
     test_idx_range = np.sort(test_idx_reorder)
     
     if dataset_str == 'citeseer':

--- a/gcn/utils.py
+++ b/gcn/utils.py
@@ -45,20 +45,18 @@ def load_data(dataset_str):
     objects = []
     for i in range(len(names)):
         with open("data/ind.{}.{}".format(dataset_str, names[i]), 'rb') as f:
-            if dataset_str == 'voc2012':            
-                objects.append(pkl.load(f))              
+            if sys.version_info > (3, 0):            
+                objects.append(pkl.load(f, encoding="ASCII"))              
             else:
                 objects.append(pkl.load(f, encoding="latin-1" ))
 
     x, y, tx, ty, allx, ally, graph = tuple(objects)
-
-    print('len ally: {}, len ty: {}'.format(len(y), len(ty)))
     
-    if dataset_str == 'voc2012':
+    if sys.version_info > (3, 0):
         test_idx_reorder = None
         with open("data/ind.{}.test.index".format(dataset_str), 'rb') as f:
                 if sys.version_info > (3, 0):               
-                    test_idx_reorder = pkl.load(f)
+                    test_idx_reorder = pkl.load(f, encoding="ASCII")
     else:
         test_idx_reorder = parse_index_file("data/ind.{}.test.index".format(dataset_str))          
     

--- a/gcn/utils.py
+++ b/gcn/utils.py
@@ -45,15 +45,25 @@ def load_data(dataset_str):
     objects = []
     for i in range(len(names)):
         with open("data/ind.{}.{}".format(dataset_str, names[i]), 'rb') as f:
-            if sys.version_info > (3, 0):
-                objects.append(pkl.load(f, encoding='latin1'))
+            if dataset_str == 'voc2012':            
+                objects.append(pkl.load(f))              
             else:
-                objects.append(pkl.load(f))
+                objects.append(pkl.load(f, encoding="latin-1" ))
 
     x, y, tx, ty, allx, ally, graph = tuple(objects)
-    test_idx_reorder = parse_index_file("data/ind.{}.test.index".format(dataset_str))
-    test_idx_range = np.sort(test_idx_reorder)
 
+    print('len ally: {}, len ty: {}'.format(len(y), len(ty)))
+    
+    if dataset_str == 'voc2012':
+        test_idx_reorder = None
+        with open("data/ind.{}.test.index".format(dataset_str), 'rb') as f:
+                if sys.version_info > (3, 0):               
+                    test_idx_reorder = pkl.load(f)
+    else:
+        test_idx_reorder = parse_index_file("data/ind.{}.test.index".format(dataset_str))          
+    
+    test_idx_range = np.sort(test_idx_reorder)
+    
     if dataset_str == 'citeseer':
         # Fix citeseer dataset (there are some isolated nodes in the graph)
         # Find isolated nodes, add them as zero-vecs into the right position


### PR DESCRIPTION
Hi @tkipf, how are you?

The file `ind.dataset_str.test.index ` was not created using `pickle` (I guess you saved the list using `open` and `write` functions).

If a user try to load the input files using `pickle` module, he gets an exception. So I changed the code to catch this exception. 

The code runs perfectly for me now, but please check if in your machine the code is still running as expected. I have tested for python 2 and 3 the load function (*but my files were created using only python 3*).

Thank you for your awesome contribution with this project. 