### PR TITLE
Added requirements file for easier pip installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pdf
 tmp/
 *.txt
+!requirements.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+networkx==2.2
+scipy==1.1.0
+setuptools==40.6.3
+numpy==1.15.4
+tensorflow==1.13.1


### PR DESCRIPTION
Add a requirements.txt file for easier pip installation by `pip install -r requirements.txt` to install dependencies, in case `python setup.py install` causes issues