### PR TITLE
Adding GPU automatic mixed precision training support

### DIFF
--- a/gcn/models.py
+++ b/gcn/models.py
@@ -1,3 +1,5 @@
+import os
+
 from gcn.layers import *
 from gcn.metrics import *
 
@@ -93,7 +95,16 @@ class MLP(Model):
         self.placeholders = placeholders
 
         self.optimizer = tf.train.AdamOptimizer(learning_rate=FLAGS.learning_rate)
-
+        
+        if os.environ.get('TF_ENABLE_AUTO_MIXED_PRECISION', default='0') == '1' or \
+           ('gpu_auto_mixed_precision' in FLAGS and FLAGS.gpu_auto_mixed_precision):
+            tf_version_list = tf.__version__.split(".")
+            if int(tf_version_list[0]) < 2:
+                if int(tf_version_list[1]) < 14:
+                    raise RuntimeError("TensorFlow>=1.14 is required for automatic precision.")
+            print("=============Enabling GPU Automatic Mixed Precision=============")
+            self.optimizer = tf.train.experimental.enable_mixed_precision_graph_rewrite(self.optimizer)
+        
         self.build()
 
     def _loss(self):
@@ -140,7 +151,15 @@ class GCN(Model):
         self.placeholders = placeholders
 
         self.optimizer = tf.train.AdamOptimizer(learning_rate=FLAGS.learning_rate)
-
+        if os.environ.get('TF_ENABLE_AUTO_MIXED_PRECISION', default='0') == '1' or \
+           ('gpu_auto_mixed_precision' in FLAGS and FLAGS.gpu_auto_mixed_precision):
+            tf_version_list = tf.__version__.split(".")
+            if int(tf_version_list[0]) < 2:
+                if int(tf_version_list[1]) < 14:
+                    raise RuntimeError("TensorFlow>=1.14 is required for automatic precision.")
+            print("=============Enabling GPU Automatic Mixed Precision=============")
+            self.optimizer = tf.train.experimental.enable_mixed_precision_graph_rewrite(self.optimizer)
+            
         self.build()
 
     def _loss(self):

--- a/gcn/train.py
+++ b/gcn/train.py
@@ -24,6 +24,8 @@ flags.DEFINE_float('dropout', 0.5, 'Dropout rate (1 - keep probability).')
 flags.DEFINE_float('weight_decay', 5e-4, 'Weight for L2 loss on embedding matrix.')
 flags.DEFINE_integer('early_stopping', 10, 'Tolerance for early stopping (# of epochs).')
 flags.DEFINE_integer('max_degree', 3, 'Maximum Chebyshev polynomial degree.')
+flags.DEFINE_bool("gpu_auto_mixed_precision", default=False,
+      help="Enabling GPU automatic mixed precision training.")
 
 # Load data
 adj, features, y_train, y_val, y_test, train_mask, val_mask, test_mask = load_data(FLAGS.dataset)


### PR DESCRIPTION
Automatic Mixed Precision training on GPU for Tensorflow has been recently introduced:

https://medium.com/tensorflow/automatic-mixed-precision-in-tensorflow-for-faster-ai-training-on-nvidia-gpus-6033234b2540

Automatic mixed precision training makes use of both FP32 and FP16 precisions where appropriate. FP16 operations can leverage the Tensor cores on NVIDIA GPUs (Volta, Turing or newer architectures) for much improved throughput.

This PR adds GPU automatic mixed precision training to `gcn` training task either via setting an OS flag `TF_ENABLE_AUTO_MIXED_PRECISION=1` or passing the flags value `--gpu_auto_mixed_precision=True`.

```
python train.py --dataset cora --gpu_auto_mixed_precision=True
```

**How mixed precision works**

Mixed precision is the use of both float16 and float32 data types when training a model.

Performing arithmetic operations in float16 takes advantage of the performance gains of using specialized processing units such as the Tensor cores on NVIDIA GPUs. Due to the smaller representable range of float16, performing the entire training with float16 data type can result in underflow of the gradients, leading to convergence or model quality issues.

However, performing only select arithmetic operations in float16 results in performance gains when using compatible hardware accelerators, decreasing training time and reducing memory usage, typically without sacrificing model performance.

To learn more about mixed precision and how it works:

   [Overview of Automatic Mixed Precision for Deep Learning](https://developer.nvidia.com/automatic-mixed-precision)
    [NVIDIA Mixed Precision Training Documentation](https://docs.nvidia.com/deeplearning/sdk/mixed-precision-training/index.html)
    [NVIDIA Deep Learning Performance Guide](https://docs.nvidia.com/deeplearning/sdk/dl-performance-guide/index.html)