### PR TITLE
Make setup.py versions match requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ setup(name='gcn',
       url='https://tkipf.github.io',
       download_url='https://github.com/tkipf/gcn',
       license='MIT',
-      install_requires=['numpy',
-                        'tensorflow',
-                        'networkx',
-                        'scipy'
+      install_requires=['numpy==1.15.4',
+                        'tensorflow==1.13.1',
+                        'networkx==2.2',
+                        'scipy==1.1.0'
                         ],
       package_data={'gcn': ['README.md']},
       packages=find_packages())


### PR DESCRIPTION
This chanage makes the packages in `setup.py` match those in `requirements.txt`, so doing `python setup.py install` will pull the right package versions. As of today, it pulls Tensorflow 2.0, which does not have a `tf.apps...` module, so setup.py will fail without this fix.

Alternatively, the README could be updated to say that `pip install -r requirements.txt` should be run before `setup.py`