### PR TITLE
Update install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ setup(name='gcn',
       url='https://tkipf.github.io',
       download_url='https://github.com/tkipf/gcn',
       license='MIT',
-      install_requires=['numpy==1.15.4',
-                        'tensorflow==1.15.2',
-                        'networkx==2.2',
-                        'scipy==1.1.0'
+      install_requires=['numpy>=1.15.4',
+                        'tensorflow>=1.15.2,<2.0',
+                        'networkx>=2.2',
+                        'scipy>=1.1.0'
                         ],
       package_data={'gcn': ['README.md']},
       packages=find_packages())


### PR DESCRIPTION
Removed fixed versions of dependencies by minimal/maximal bounds.

Pinning dependencies to fixed versions often clashes with
dependencies of other packages, and is therefore not adviced.

Change the previous versions to lower bounds. Additionally
restrict tensorflow to 1.x